### PR TITLE
Rename mjs files to js

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,4 @@ module.exports = {
     "\\.(css|less)$": "<rootDir>/src/testing/styleMock.js"
   },
   testEnvironment: "jsdom",
-  moduleFileExtensions: ["js", "jsx", "mjs"],
-  testMatch: [ "**/__tests__/**/*.?(m)[jt]s?(x)", "**/?(*.)+(spec|test).?(m)[jt]s?(x)" ]
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "watch-firefox": "webpack --config webpack/webpack.dev.js  --env browser=firefox --watch",
     "build-firefox": "webpack --config webpack/webpack.prod.js --env browser=firefox",
     "build-firefox-dev": "webpack --config webpack/webpack.dev.js --env browser=firefox",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "jest",
     "clean": "rimraf dist",
     "zip": "npm run clean && npm run build && cd dist && bestzip ../wikitree-browser-extension.zip *"
   },

--- a/src/content.js
+++ b/src/content.js
@@ -1,6 +1,6 @@
 //import { createTopMenu } from "./core/common";
 
-import "./features/register_feature_options.mjs";
+import "./features/register_feature_options";
 
 import "./features/agc/agc_content";
 import "./features/akaNameLinks/akaNameLinks";

--- a/src/core/options/options_registry.js
+++ b/src/core/options/options_registry.js
@@ -1,7 +1,7 @@
 
 
 // an array of information about features and their options
-// This is constructed by the features registering their options in register_feature_options.mjs
+// This is constructed by the features registering their options in register_feature_options.js
 const features = [
 ];
 

--- a/src/core/options/options_storage.js
+++ b/src/core/options/options_storage.js
@@ -1,4 +1,4 @@
-import { getDefaultOptionValuesForFeature } from "../../core/options/options_registry.mjs"
+import { getDefaultOptionValuesForFeature } from "./options_registry"
 
 /*
 This function returns a Promise so it can be used in a couple of different ways:

--- a/src/features/agc/agc.test.js
+++ b/src/features/agc/agc.test.js
@@ -27,10 +27,10 @@ import fs from 'fs'
 import {fail} from 'assert';
 
 // need to include this to register the feature so that we can get the default options
-import "../register_feature_options.mjs";
+import "../register_feature_options";
 
 
-import { getDefaultOptionValuesForFeature } from "../../core/options/options_registry.mjs"
+import { getDefaultOptionValuesForFeature } from "../../core/options/options_registry"
 
 const defaultUserOptions = getDefaultOptionValuesForFeature("agc", true);
 

--- a/src/features/agc/agc_content.js
+++ b/src/features/agc/agc_content.js
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-import { checkIfFeatureEnabled, getFeatureOptions } from "../../core/options/options_storage.mjs"
+import { checkIfFeatureEnabled, getFeatureOptions } from "../../core/options/options_storage"
 
 // file level variables
 var agcButton = undefined;

--- a/src/features/agc/agc_options.js
+++ b/src/features/agc/agc_options.js
@@ -1,4 +1,4 @@
-import { registerFeature, OptionType } from "../../core/options/options_registry.mjs"
+import { registerFeature, OptionType } from "../../core/options/options_registry"
 
 // The feature data for the AGC feature
 const agcFeature = {

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -1,4 +1,4 @@
-import { registerFeature } from "../core/options/options_registry.mjs"
+import { registerFeature } from "../core/options/options_registry"
 
 // Just importing this file will register all the features
 
@@ -7,7 +7,7 @@ import { registerFeature } from "../core/options/options_registry.mjs"
 // the feature and options
 ////////////////////////////////////////////////////////////////////////////////
 
-import "./agc/agc_options.mjs";
+import "./agc/agc_options.js";
 
 ////////////////////////////////////////////////////////////////////////////////
 // Simple features with no options can be registered here

--- a/src/options.js
+++ b/src/options.js
@@ -1,7 +1,7 @@
 import $ from "jquery";
 
-import { features, OptionType } from "./core/options/options_registry.mjs";
-import "./features/register_feature_options.mjs";
+import { features, OptionType } from "./core/options/options_registry";
+import "./features/register_feature_options";
 
 
 // Categories


### PR DESCRIPTION
The changes to jest configuration aren't needed when all files have .js extensions and imports don't specify the file extension. I'm not an expert on ES modules but this works for me.